### PR TITLE
Specify YACL dependency correctly in fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,9 +26,7 @@
 		"fabricloader": ">=0.14.13",
 		"minecraft": "~1.19.3",
 		"java": ">=17",
-		"fabric-api": "*"
-	},
-	"dependencies": {
+		"fabric-api": "*",
 		"yet-another-config-lib": ">=2.1.1"
 	}
 }


### PR DESCRIPTION
Dependencies are specified in "depends", not "dependencies". The YACL documentation is incorrect.