### PR TITLE
add Display Attempts when found!

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.4+build.1
 loader_version=0.16.9
 
 # Mod Properties
-mod_version=2.2.5
+mod_version=2.2.6
 maven_group=de.greenman999.librariantradefinder
 archives_base_name=librarian-trade-finder
 

--- a/src/main/java/de/greenman999/librariantradefinder/mixin/ClientConnectionMixin.java
+++ b/src/main/java/de/greenman999/librariantradefinder/mixin/ClientConnectionMixin.java
@@ -78,12 +78,20 @@ public class ClientConnectionMixin {
 
     @Unique
     private void foundEnchantment(AtomicBoolean found, TradeOffer tradeOffer, Enchantment enchantment, int level) {
+        int attempts = TradeFinder.tries; // Save the attempts BEFORE calling stop()
         TradeFinder.stop();
         found.set(true);
-        MinecraftClient.getInstance().inGameHud.getChatHud().addMessage(Text.translatable(
-                "librarian-trade-finder.found",
-                Enchantment.getName(RegistryEntry.of(enchantment), level),
-                tradeOffer.getOriginalFirstBuyItem().getCount()).formatted(Formatting.GREEN));
+
+        MinecraftClient.getInstance().inGameHud.getChatHud().addMessage(
+                Text.translatable(
+                        "librarian-trade-finder.found",
+                        Enchantment.getName(RegistryEntry.of(enchantment), level),
+                        tradeOffer.getOriginalFirstBuyItem().getCount(),
+                        Text.literal(String.valueOf(attempts))
+                                .styled(style -> style.withColor(0xcc1141))
+                ).formatted(Formatting.GREEN)
+        );
     }
+
 
 }

--- a/src/main/resources/assets/librarian-trade-finder/lang/de_de.json
+++ b/src/main/resources/assets/librarian-trade-finder/lang/de_de.json
@@ -16,7 +16,7 @@
   "librarian-trade-finder.actionbar.status.place": "Lesepult platzieren --- Versuch: %d",
   "librarian-trade-finder.check.interact.failed": "Interaktion mit Dorfbewohner fehlgeschlagen. Versuchen Sie es erneut.",
   "librarian-trade-finder.break.axe.breaking": "Der Suchvorgang wurde unterbrochen, weil Ihre Axt zu zerbrechen droht.",
-  "librarian-trade-finder.found": "Verzauberung %d für %d Smaragde gefunden!",
+  "librarian-trade-finder.found": "Verzauberung %d für %d Smaragde, nach %d Versuche gefunden!",
   "tradefinderui.screen.title": "Bibliothekar Tausch Finder",
   "tradefinderui.options.title": "Optionen",
   "tradefinderui.buttons.save": "Speichern & Schließen",

--- a/src/main/resources/assets/librarian-trade-finder/lang/en_us.json
+++ b/src/main/resources/assets/librarian-trade-finder/lang/en_us.json
@@ -16,7 +16,7 @@
   "librarian-trade-finder.actionbar.status.place": "placing lectern --- attempt: %d",
   "librarian-trade-finder.check.interact.failed": "Failed to interact with villager. Try again.",
   "librarian-trade-finder.break.axe.breaking": "The searching process was stopped because your axe is about to break.",
-  "librarian-trade-finder.found": "Found enchantment %d for %d emeralds!",
+  "librarian-trade-finder.found": "Found enchantment %d for %d emeralds after %d attempts!",
   "tradefinderui.screen.title": "Librarian Trade Finder",
   "tradefinderui.options.title": "Options",
   "tradefinderui.buttons.save": "Save & Exit",


### PR DESCRIPTION
Heya, 

I made a small tweak to the mod. now the message you see when an enchantment is found includes how many attempts it took to find it. Thought it’d be cool to know that, especially when we're grinding for a while.

The number of attempts is in a custom red color (a favorite of mine), so it stands out nicely. Everything else works like it did before, just a small addition.

> ### Changes:
> - **Preserved Attempts:**
>   - Saved TradeFinder.tries before stop() resets it, so we get the correct count in the message.
> - **Localized Message:**
>   - Updated "librarian-trade-finder.found" in the English & German localization file to include attempts.

Note:
I only updated the English & German localization since I don’t know the other languages that well. I hope someone else can add them later!
